### PR TITLE
replace token targetting with a broadcast topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ How To Use
 
 1. install dependencies with `npm install`
 2. download the service account private key for the project/environment from `https://console.firebase.google.com/u/0/project/<Project ID>/settings/serviceaccounts/adminsdk` and put it in the root of this repo. It has to be named "serviceAccountKey.json". **DO NOT CHECK THIS PRIVATE KEY INTO ANY REPO OR YOU WILL BE FIRED**.
-3. Send a notification with `node index.js --token <str> --title <str> --body <str> --article-url <url> --image-url [url]`
+3. Send a notification with `node index.js --title <str> --body <str> --article-url <url> --image-url [url]`
 
 Example
 -------
 
 ```terminal
 node index.js \
-    --token SOME_FIREBASE_TOKEN \
     --title "EXCLUSIVE: This is a notification" \
     --body "Here is some longer copy, usually a summary of the article" \
     --article-url https://www.thetimes.co.uk/article/58m-lottery-win-almost-in-tatters-0052w73vz \

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const firebase = require("firebase-admin");
 const serviceAccountKey = require("./serviceAccountKey.json");
 const argv = require("yargs")
   .usage(
-    "Usage: $0 --token <str> --title <str> --body <str> --article-url <url> --image-url [url]"
+    "Usage: $0 --title <str> --body <str> --article-url <url> --image-url [url]"
   )
-  .demandOption(["token", "title", "article-url", "image-url"]).argv;
+  .demandOption(["title", "article-url", "image-url"]).argv;
 
 // android push payloads cannot have a "notification" object, or inherit one.
 // If they do, then the firebase service on the device controls the notification,
@@ -46,7 +46,7 @@ firebase
     })
   )
   .send({
-    token: argv["token"],
+    topic: "exclusives",
     android: android,
     apns: apns
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "times-push-notifier",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "sends notifications to times apps",
   "main": "index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This allows us to broadcast a notification instead of the single notifications that we currently send.