### PR TITLE
Include send-date as milliseconds since epoch for notification metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ const apns = {
     },
     type: "exclusives",
     "article-url": argv["article-url"],
-    "image-url": argv["image-url"]
+    "image-url": argv["image-url"],
+    "send-date": Date.now()
   }
 };
 


### PR DESCRIPTION
Include a send-date that can be passed through to analytics.